### PR TITLE
fix(mihomo): restore IPC response URL and lowercase enum parsing

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -28,6 +28,7 @@ use tokio::{
 use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
 
 use crate::{Error, Result};
+use reqwest::ResponseBuilderExt;
 
 #[pin_project(project = WrapStreamProj)]
 pub enum WrapStream {
@@ -600,7 +601,14 @@ impl LocalSocket for RequestBuilder {
                 .map_err(|e| Error::HttpParseError(e.to_string()))?
                 .to_bytes();
 
-            let final_res = http::Response::from_parts(res_parts, collected_body);
+            let mut builder = http::Response::builder()
+                .status(res_parts.status)
+                .version(res_parts.version);
+            *builder.headers_mut().expect("builder is freshly created") = res_parts.headers;
+            let final_res = builder
+                .url(url.clone())
+                .body(collected_body)
+                .map_err(|e| Error::HttpParseError(e.to_string()))?;
 
             Ok(reqwest::Response::from(final_res))
         };

--- a/src/models.rs
+++ b/src/models.rs
@@ -409,23 +409,24 @@ pub struct BrutalOption {
 
 #[derive(Debug, Serialize, TS, PartialEq, Eq)]
 #[ts(export)]
+#[serde(rename_all = "lowercase")]
 pub enum LogLevel {
-    DEBUG,
-    INFO,
-    WARNING,
-    ERROR,
-    SILENT,
+    Debug,
+    Info,
+    Warning,
+    Error,
+    Silent,
 }
 
 impl<'de> Deserialize<'de> for LogLevel {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
         let value = String::deserialize(deserializer)?;
         match value.as_str() {
-            "DEBUG" | "debug" => Ok(LogLevel::DEBUG),
-            "INFO" | "info" => Ok(LogLevel::INFO),
-            "WARNING" | "warning" => Ok(LogLevel::WARNING),
-            "ERROR" | "error" => Ok(LogLevel::ERROR),
-            "SILENT" | "silent" => Ok(LogLevel::SILENT),
+            "DEBUG" | "debug" => Ok(LogLevel::Debug),
+            "INFO" | "info" => Ok(LogLevel::Info),
+            "WARNING" | "warning" => Ok(LogLevel::Warning),
+            "ERROR" | "error" => Ok(LogLevel::Error),
+            "SILENT" | "silent" => Ok(LogLevel::Silent),
             _ => Err(serde::de::Error::unknown_variant(
                 &value,
                 &[
@@ -440,11 +441,11 @@ impl Display for LogLevel {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LogLevel::DEBUG => write!(f, "debug"),
-            LogLevel::INFO => write!(f, "info"),
-            LogLevel::WARNING => write!(f, "warning"),
-            LogLevel::ERROR => write!(f, "error"),
-            LogLevel::SILENT => write!(f, "silent"),
+            LogLevel::Debug => write!(f, "debug"),
+            LogLevel::Info => write!(f, "info"),
+            LogLevel::Warning => write!(f, "warning"),
+            LogLevel::Error => write!(f, "error"),
+            LogLevel::Silent => write!(f, "silent"),
         }
     }
 }
@@ -462,6 +463,7 @@ pub struct GeoXUrl {
 
 #[derive(Debug, Serialize, TS, PartialEq, Eq)]
 #[ts(export)]
+#[serde(rename_all = "lowercase")]
 pub enum FindProcessMode {
     Strict,
     Always,
@@ -867,21 +869,23 @@ pub struct RuleProviders {
 
 #[derive(Debug, Serialize, Deserialize, TS, PartialEq, Eq)]
 #[ts(export)]
+#[serde(rename_all = "lowercase")]
 pub enum RuleBehavior {
     Domain,
-    #[serde(rename = "IPCIDR")]
+    #[serde(rename = "ipcidr")]
     IpCidr,
     Classical,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS, PartialEq, Eq)]
 #[ts(export)]
+#[serde(rename_all = "lowercase")]
 pub enum RuleFormat {
-    #[serde(rename = "YamlRule")]
+    #[serde(rename = "yamlrule")]
     Yaml,
-    #[serde(rename = "TextRule")]
+    #[serde(rename = "textrule")]
     Text,
-    #[serde(rename = "MrsRule")]
+    #[serde(rename = "mrsrule")]
     Mrs,
 }
 


### PR DESCRIPTION
Fixes the tauri-plugin-mihomo side of clash-verge-rev/clash-verge-rev#7282 and #7316.

Summary:
- Restore ResponseUrl on local-socket HTTP responses so reqwest body decoding can resolve a real URL instead of http://no.url.provided.local/
- Keep mihomo config enum parsing aligned with the lowercase values returned by the core
- Leave ProviderType / VehicleType unchanged because they use PascalCase in the actual JSON

Verification:
- cargo check -p tauri-plugin-mihomo
- local smoke test: homepage data and proxy groups load normally again